### PR TITLE
feat: Add two media file download nodes

### DIFF
--- a/nodes/Lark/resource/space/MediaDownload.operation.ts
+++ b/nodes/Lark/resource/space/MediaDownload.operation.ts
@@ -1,0 +1,59 @@
+import { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+import RequestUtils from '../../../help/utils/RequestUtils';
+import { ResourceOperation } from '../../../help/type/IResource';
+import { WORDING } from '../../../help/wording';
+import { OperationType } from '../../../help/type/enums';
+import { DESCRIPTIONS } from '../../../help/description';
+
+export default {
+	name: WORDING.DownloadMedia,
+	value: OperationType.DownloadMediaToSpace,
+	order: 150,
+	options: [
+		DESCRIPTIONS.MEDIA_FILE_TOKEN,
+		{
+			displayName: WORDING.Options,
+			name: 'options',
+			type: 'collection',
+			placeholder: WORDING.AddField,
+			default: {},
+			options: [
+				{
+					...DESCRIPTIONS.REQUEST_BODY,
+					name: 'media_download_extra',
+				},
+			],
+		},
+		{
+			displayName: `<a target="_blank" href="https://open.feishu.cn/document/server-docs/docs/drive-v1/media/download">${WORDING.OpenDocument}</a>`,
+			name: 'notice',
+			type: 'notice',
+			default: '',
+		},
+	],
+	async call(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+		const fileToken = this.getNodeParameter('media_file_token', index) as string;
+
+		const options = this.getNodeParameter('options', index, {});
+		const extra = (options.media_download_extra as IDataObject) || undefined;
+
+
+		let url = `/open-apis/drive/v1/medias/${fileToken}/download`
+		if (extra) {
+			url += `?extra=${encodeURIComponent(JSON.stringify(extra))}`
+		}
+
+		const buffer = await RequestUtils.request.call(this, {
+			method: 'GET',
+			url,
+			encoding: 'arraybuffer',
+			json: false,
+		});
+
+		const binaryData = await this.helpers.prepareBinaryData(buffer);
+
+		return {
+			...binaryData,
+		};
+	},
+} as ResourceOperation;

--- a/nodes/Lark/resource/space/MediaGetTmpDownloadUrl.operation.ts
+++ b/nodes/Lark/resource/space/MediaGetTmpDownloadUrl.operation.ts
@@ -1,0 +1,68 @@
+import { IDataObject, IExecuteFunctions } from 'n8n-workflow';
+import RequestUtils from '../../../help/utils/RequestUtils';
+import { ResourceOperation } from '../../../help/type/IResource';
+import { WORDING } from '../../../help/wording';
+import { OperationType } from '../../../help/type/enums';
+import { DESCRIPTIONS } from '../../../help/description';
+
+export default {
+	name: WORDING.GetMediaTempDownloadLink,
+	value: OperationType.GetMediaTempDownloadLinkToSpace,
+	order: 140,
+	options: [
+		DESCRIPTIONS.MEDIA_FILE_TOKEN,
+		{
+			displayName: WORDING.Options,
+			name: 'options',
+			type: 'collection',
+			placeholder: WORDING.AddField,
+			default: {},
+			options: [
+				{
+					...DESCRIPTIONS.REQUEST_BODY,
+					name: 'media_tmp_download_extra',
+				},
+			],
+		},
+		{
+			displayName: `<a target="_blank" href="https://open.feishu.cn/document/server-docs/docs/drive-v1/media/batch_get_tmp_download_url">${WORDING.OpenDocument}</a>`,
+			name: 'notice',
+			type: 'notice',
+			default: '',
+		},
+	],
+	async call(this: IExecuteFunctions, index: number): Promise<IDataObject> {
+
+		let fileTokens: string[];
+
+
+		// 使用字符串输入
+		const fileTokensInput = this.getNodeParameter('media_file_token', index) as string;
+		fileTokens = fileTokensInput.split(',').map(token => token.trim()).filter(token => token);
+
+		// 限制最多5个token
+		if (fileTokens.length > 5) {
+			throw new Error('Maximum 5 file tokens are allowed');
+		}
+
+		if (fileTokens.length === 0) {
+			throw new Error('At least one file token is required');
+		}
+
+		const options = this.getNodeParameter('options', index, {});
+		const extra = (options.media_tmp_download_extra as IDataObject) || undefined;
+
+		let url = `/open-apis/drive/v1/medias/batch_get_tmp_download_url?${fileTokens.map((token)=>`file_tokens=${token}`).join('&')}`
+
+		if (extra) {
+			url += `&extra=${encodeURIComponent(JSON.stringify(extra))}`
+		}
+		const { data } = await RequestUtils.request.call(this, {
+			method: 'GET',
+			url,
+			json: true,
+		});
+
+		return data;
+	},
+} as ResourceOperation;

--- a/nodes/help/description/index.ts
+++ b/nodes/help/description/index.ts
@@ -10,6 +10,16 @@ export const DESCRIPTIONS = {
 		description: 'The name of the field that will contain the file binary data',
 	},
 
+	MEDIA_FILE_TOKEN: {
+		displayName: 'File Token(素材文件token)',
+		description: 'The token of the media file to download',
+		name: 'media_file_token',
+		// eslint-disable-next-line n8n-nodes-base/node-param-type-options-password-missing
+		type: 'string',
+		required: true,
+		default: '',
+	},
+
 	PARENT_TYPE: {
 		displayName: 'Upload Point Type(上传点的类型)',
 		name: 'parent_type',

--- a/nodes/help/type/enums.ts
+++ b/nodes/help/type/enums.ts
@@ -119,6 +119,8 @@ export declare const enum OperationType {
 	SearchFiles = 'searchFiles',
 	UploadFileToSpace = 'uploadFile',
 	UploadMediaToSpace = 'uploadMedia',
+	DownloadMediaToSpace = 'downloadMedia',
+	GetMediaTempDownloadLinkToSpace = 'getMediaTempDownloadLink',
 
 	// Contact
 	BatchGetUserInfo = 'batchGetUserInfo',

--- a/nodes/help/wording/index.ts
+++ b/nodes/help/wording/index.ts
@@ -92,6 +92,8 @@ export const WORDING = {
 	SearchFiles: 'Search Files | 搜索文档',
 	UploadFileAll: 'Upload File | 上传文件',
 	UploadMedia: 'Upload Media | 上传素材',
+	DownloadMedia: 'Download Media | 下载素材',
+	GetMediaTempDownloadLink: 'Get Media Temp Download Link | 获取素材临时下载链接',
 
 	// Contact
 	BatchGetUserInfo: 'Batch Get User Info | 批量获取用户信息',


### PR DESCRIPTION
According to the development documentation:
- https://open.feishu.cn/document/server-docs/docs/drive-v1/media/download
- https://open.feishu.cn/document/server-docs/docs/drive-v1/media/batch_get_tmp_download_url

Add two nodes for downloading materials