### PR TITLE
fix: move glob to production dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
 			"dependencies": {
 				"crypto": "^1.0.1",
 				"form-data": "^4.0.4",
+				"glob": "^11.0.3",
 				"isbot": "^5.1.32",
 				"luxon": "^3.7.2",
 				"protobufjs": "^7.5.3",
@@ -27,7 +28,6 @@
 				"@typescript-eslint/parser": "~8.35.1",
 				"eslint": "^8.57.1",
 				"eslint-plugin-n8n-nodes-base": "^1.16.3",
-				"glob": "^11.0.3",
 				"gulp": "^5.0.1",
 				"jest": "^29.7.0",
 				"prettier": "^3.6.2",
@@ -760,7 +760,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
 			"integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": "20 || >=22"
@@ -770,7 +769,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.0.tgz",
 			"integrity": "sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@isaacs/balanced-match": "^4.0.1"
@@ -783,7 +781,6 @@
 			"version": "8.0.2",
 			"resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
 			"integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^5.1.2",
@@ -801,7 +798,6 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
 			"integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -814,14 +810,12 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@isaacs/cliui/node_modules/string-width": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
 			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -839,7 +833,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
 			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"
@@ -2912,7 +2905,6 @@
 			"version": "7.0.6",
 			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
 			"integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -3177,7 +3169,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
 			"integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
@@ -3884,7 +3875,6 @@
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
 			"integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
@@ -4062,7 +4052,6 @@
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
 			"integrity": "sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"foreground-child": "^3.3.1",
@@ -4133,7 +4122,6 @@
 			"version": "10.0.3",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.0.3.tgz",
 			"integrity": "sha512-IPZ167aShDZZUMdRk66cyQAW3qr0WzbHkPdMYa8bzZhlHhO3jALbKdxcaak7W9FfT2rZNpQuUu4Od7ILEpXSaw==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"@isaacs/brace-expansion": "^5.0.0"
@@ -4905,7 +4893,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -4993,7 +4980,6 @@
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-4.1.1.tgz",
 			"integrity": "sha512-zptv57P3GpL+O0I7VdMJNBZCu+BPHVQUk55Ft8/QCJjTVxrnJHuVuX/0Bl2A6/+2oyR/ZMEuFKwmzqqZ/U5nPQ==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"@isaacs/cliui": "^8.0.2"
@@ -6133,7 +6119,6 @@
 			"version": "7.1.2",
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
 			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=16 || 14 >=14.17"
@@ -6500,7 +6485,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
-			"dev": true,
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/parent-module": {
@@ -6601,7 +6585,6 @@
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -6641,7 +6624,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.0.tgz",
 			"integrity": "sha512-ypGJsmGtdXUOeM5u93TyeIEfEhM6s+ljAhrk5vAvSx8uyY/02OvrZnA0YNGUrPXfpJMgI1ODd3nwz8Npx4O4cg==",
-			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
 				"lru-cache": "^11.0.0",
@@ -6658,7 +6640,6 @@
 			"version": "11.2.1",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.1.tgz",
 			"integrity": "sha512-r8LA6i4LP4EeWOhqBaZZjDWwehd1xUJPCJd9Sv300H0ZmcUER4+JPh7bqqZeqs1o5pgtgvXm+d9UGrB5zZGDiQ==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": "20 || >=22"
@@ -7364,7 +7345,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -7377,7 +7357,6 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -7387,7 +7366,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
 			"integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-			"dev": true,
 			"license": "ISC",
 			"engines": {
 				"node": ">=14"
@@ -7556,7 +7534,6 @@
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
 			"integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"emoji-regex": "^8.0.0",
@@ -7584,7 +7561,6 @@
 			"version": "6.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^5.0.1"
@@ -8297,7 +8273,6 @@
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -8352,7 +8327,6 @@
 			"version": "8.1.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
 			"integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^6.1.0",
@@ -8371,7 +8345,6 @@
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
 			"integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.0.0",
@@ -8389,7 +8362,6 @@
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"color-convert": "^2.0.1"
@@ -8405,7 +8377,6 @@
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.0.tgz",
 			"integrity": "sha512-TKY5pyBkHyADOPYlRT9Lx6F544mPl0vS5Ew7BJ45hA08Q+t3GjbueLliBWN3sMICk6+y7HdyxSzC4bWS8baBdg==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -8418,7 +8389,6 @@
 			"version": "6.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
 			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=12"
@@ -8431,14 +8401,12 @@
 			"version": "9.2.2",
 			"resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
 			"integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/wrap-ansi/node_modules/string-width": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
 			"integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"eastasianwidth": "^0.2.0",
@@ -8456,7 +8424,6 @@
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.0.tgz",
 			"integrity": "sha512-iq6eVVI64nQQTRYq2KtEg2d2uU7LElhTJwsH4YzIHZshxlgZms/wIc4VoDQTlG/IvVIrBKG06CrZnp0qv7hkcQ==",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-regex": "^6.0.1"

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
 		"@typescript-eslint/parser": "~8.35.1",
 		"eslint": "^8.57.1",
 		"eslint-plugin-n8n-nodes-base": "^1.16.3",
-		"glob": "^11.0.3",
 		"gulp": "^5.0.1",
 		"jest": "^29.7.0",
 		"prettier": "^3.6.2",
@@ -73,7 +72,8 @@
 		"protobufjs": "^7.5.3",
 		"sanitize-html": "^2.17.0",
 		"ws": "^8.18.3",
-		"uuid": "^11.1.0"
+		"uuid": "^11.1.0",
+		"glob": "^11.0.3"
 	},
 	"overrides": {
 		"pkce-challenge": "4.0.0"


### PR DESCRIPTION
## Summary

Runtime code imports `glob`:

```ts
// nodes/help/utils/ModuleLoadUtils.ts
import { globSync } from 'glob';
```

but `glob` was only listed under **devDependencies**.

When n8n installs a community package it:

1. Downloads the tarball
2. **Strips `devDependencies` / `peerDependencies` / `optionalDependencies` from `package.json`**
3. Runs `npm install` inside the package directory
4. Loads the package with **module isolation** (`load-class-in-isolation`)

As a result, `glob` is never installed for production use, and newer n8n versions no longer accidentally resolve it from the host app’s own `node_modules`. Installing or reinstalling this package on n8n 2.x fails with:

```text
Error loading package "n8n-nodes-feishu-lark"
Cause: Cannot find module 'glob'
```

This often surfaces right after **upgrading n8n** (isolation is stricter), and UI uninstall/reinstall does not help because the published package is still missing the production dependency.

## Change

- Move `glob` from `devDependencies` → `dependencies` (`^11.0.3`, same range as before)
- Update `package-lock.json` accordingly (`dev: true` removed for `glob` and its transitive deps)

No runtime logic changes.

## Test plan

- [ ] Fresh install of this package on n8n 2.x (Docker or npm) without any manual `npm install glob`
- [ ] Confirm Settings → Community nodes lists `n8n-nodes-feishu-lark` and nodes **Lark** / **Lark Trigger** appear in the palette
- [ ] Confirm workflows using `n8n-nodes-feishu-lark.lark` activate without `Unrecognized node type` / `Cannot find module 'glob'`
- [ ] After release, bump npm version and publish so UI “install from npm” picks up the fix

## Workaround (until a fixed version is published)

If you are already broken on an existing n8n Docker instance, you can apply this **one-click style fix** after the package is present on disk (install once from UI even if it errors, or ensure the folder exists under `~/.n8n/nodes/node_modules/`).

### Docker (container name `n8n`)

```bash
#!/usr/bin/env bash
# fix-n8n-nodes-feishu-lark-glob.sh
# Temporary workaround until n8n-nodes-feishu-lark ships glob as a production dependency.
set -euo pipefail

CONTAINER="${N8N_CONTAINER:-n8n}"
PKG_DIR="/home/node/.n8n/nodes/node_modules/n8n-nodes-feishu-lark"
GLOB_VERSION="${GLOB_VERSION:-10.4.5}"

docker exec -u node "$CONTAINER" sh -c "
set -e
if [ ! -d '$PKG_DIR' ]; then
  echo \"Package not found at $PKG_DIR\"
  echo 'Install n8n-nodes-feishu-lark from Community nodes first, then re-run this script.'
  exit 1
fi
cd '$PKG_DIR'
node -e '
const fs = require(\"fs\");
const p = JSON.parse(fs.readFileSync(\"package.json\", \"utf8\"));
p.dependencies = p.dependencies || {};
p.dependencies.glob = process.env.GLOB_VERSION || \"$GLOB_VERSION\";
if (p.devDependencies) delete p.devDependencies.glob;
fs.writeFileSync(\"package.json\", JSON.stringify(p, null, 2));
console.log(\"package.json dependencies.glob =\", p.dependencies.glob);
'
npm install \"glob@$GLOB_VERSION\" --omit=dev --no-fund --no-audit --install-strategy=nested
node -e 'require(\"glob\"); console.log(\"glob resolve OK\")'
"

docker restart "$CONTAINER"
echo "Done. Hard-refresh the n8n UI (Ctrl+Shift+R) and check Community nodes / Lark workflows."
```

Usage:

```bash
chmod +x fix-n8n-nodes-feishu-lark-glob.sh
./fix-n8n-nodes-feishu-lark-glob.sh
# optional:
# N8N_CONTAINER=my-n8n GLOB_VERSION=11.0.3 ./fix-n8n-nodes-feishu-lark-glob.sh
```

### Notes for operators

1. Prefer **pinning the n8n image** (e.g. `n8nio/n8n:2.30.4`) instead of `:latest` so upgrades are intentional.
2. After upgrading n8n, check logs before treating the upgrade as successful:

   ```bash
   docker logs n8n --since 5m 2>&1 | grep -iE 'Error loading package|Cannot find module|Unrecognized node type'
   ```

3. Do **not** rely on UI uninstall/reinstall for this bug until a fixed npm release is published—it will reinstall the broken package.

## Related

- Runtime require: `nodes/help/utils/ModuleLoadUtils.ts` → `globSync`
- n8n community install path strips `devDependencies` before `npm install` in the package directory

Thanks for maintaining this package—happy to adjust the version range if you prefer locking to a specific `glob` major.